### PR TITLE
Disable env -> long fallback by default

### DIFF
--- a/command.go
+++ b/command.go
@@ -80,10 +80,10 @@ type lookup struct {
 func (c *Command) AddCommand(command string, shortDescription string, longDescription string, data interface{}) (*Command, error) {
 	var cmd *Command
 	if z, ok := data.(ZModule); ok {
-		cmd = newCommand(command, shortDescription, longDescription, z.NewFlags())
+		cmd = newCommand(command, shortDescription, longDescription, z.NewFlags(), c.Group.parser)
 		cmd.module = z
 	} else {
-		cmd = newCommand(command, shortDescription, longDescription, data)
+		cmd = newCommand(command, shortDescription, longDescription, data, c.Group.parser)
 	}
 	cmd.parent = c
 
@@ -99,7 +99,7 @@ func (c *Command) AddCommand(command string, shortDescription string, longDescri
 // data needs to be a pointer to a struct from which the fields indicate which
 // options are in the group.
 func (c *Command) AddGroup(shortDescription string, longDescription string, data interface{}) (*Group, error) {
-	group := newGroup(shortDescription, longDescription, data)
+	group := newGroup(shortDescription, longDescription, data, c.Group.parser)
 
 	group.parent = c
 
@@ -162,9 +162,9 @@ func (c *Command) Args() []*Arg {
 	return ret
 }
 
-func newCommand(name string, shortDescription string, longDescription string, data interface{}) *Command {
+func newCommand(name string, shortDescription string, longDescription string, data interface{}, parser *Parser) *Command {
 	return &Command{
-		Group: newGroup(shortDescription, longDescription, data),
+		Group: newGroup(shortDescription, longDescription, data, parser),
 		Name:  name,
 	}
 }

--- a/fallback_test.go
+++ b/fallback_test.go
@@ -128,7 +128,125 @@ func TestFallback(t *testing.T) {
 		for envKey, envValue := range test.env {
 			os.Setenv(envKey, envValue)
 		}
-		_, _, _, err := ParseArgs(&opts, test.args)
+		_, _, _, err := NewParser(&opts, Default | EnvironmentFallback).ParseCommandLine(test.args)
+		if err != nil {
+			t.Fatalf("%s:\nUnexpected error: %v", test.msg, err)
+		}
+
+		if opts.Slice == nil {
+			opts.Slice = []int{}
+		}
+
+		if !reflect.DeepEqual(opts, test.expected) {
+			t.Errorf("%s:\nUnexpected options with arguments %+v\nexpected\n%+v\nbut got\n%+v\n", test.msg, test.args, test.expected, opts)
+		}
+	}
+}
+
+// Test that when `long` is absent, it attempts to fall back to `json`, and
+// when `env` is absent, it attempts to fall back to `long` (and to `json`)
+func TestNoFallback(t *testing.T) {
+	type Options struct {
+		Int   int            `long:"int" json:"json-int" default:"1"`
+		Time  time.Duration  `json:"time" default:"1m"`
+		Map   map[string]int `json:"map,omitempty" default:"a:1" env-delim:";"`
+		Slice []int          `long:"slice" default:"1" default:"2" env:"OVERRIDE_SLICE" env-delim:","`
+	}
+
+	var tests = []struct {
+		msg      string
+		args     []string
+		expected Options
+		env      map[string]string
+	}{
+		{
+			msg:  "JSON override",
+			args: []string{},
+			expected: Options{
+				Int: 1,
+				Time: time.Minute * 1,
+				Map: map[string]int{"a": 1},
+				Slice: []int{3,4,5},
+			},
+			env: map[string]string{
+				"json-int": "4",
+				"int": "23",
+				"time": "3m",
+				"map": "key1:1",
+				"slice": "3,2,1",
+				"OVERRIDE_SLICE": "3,4,5",
+			},
+		},
+		{
+			msg:  "no arguments, no env, expecting default values",
+			args: []string{},
+			expected: Options{
+				Int:   1,
+				Time:  time.Minute,
+				Map:   map[string]int{"a": 1},
+				Slice: []int{1, 2},
+			},
+		},
+		{
+			msg:  "no arguments, env defaults, no fallback, expecting default values (except slice)",
+			args: []string{},
+			expected: Options{
+				Int:   1,
+				Time:  time.Minute,
+				Map:   map[string]int{"a": 1},
+				Slice: []int{4, 5, 6},
+			},
+			env: map[string]string{
+				"Int": "2",
+				"Time": "2m",
+				"Map": "a:2;b:3",
+				"OVERRIDE_SLICE": "4,5,6",
+			},
+		},
+		{
+			msg:  "non-zero value arguments, expecting overwritten arguments",
+			args: []string{"--int=3", "--time=3ms", "--map=c:3", "--slice=3", "--map=d:4", "--slice=1"},
+			expected: Options{
+				Int:   3,
+				Time:  3 * time.Millisecond,
+				Map:   map[string]int{"c": 3,"d":4},
+				Slice: []int{3,1},
+			},
+			env: map[string]string{
+				"Int": "2",
+				"Time": "2m",
+				"Map": "a:2;b:3",
+				"OVERRIDE_SLICE": "4,5,6",
+			},
+		},
+		{
+			msg:  "zero value arguments, expecting overwritten arguments",
+			args: []string{"--int=0", "--time=0ms", "--map=:0", "--slice=0"},
+			expected: Options{
+				Int:   0,
+				Time:  0,
+				Map:   map[string]int{"": 0},
+				Slice: []int{0},
+			},
+			env: map[string]string{
+				"Int": "2",
+				"Time": "2m",
+				"Map": "a:2;b:3",
+				"OVERRIDE_SLICE": "4,5,6",
+			},
+		},
+	}
+
+	oldEnv := EnvSnapshot()
+	defer oldEnv.Restore()
+
+	for _, test := range tests {
+		var opts Options
+		oldEnv.Restore()
+		for envKey, envValue := range test.env {
+			os.Setenv(envKey, envValue)
+		}
+		_, _, _, err := NewParser(&opts, Default & (^EnvironmentFallback)).ParseCommandLine(test.args)
 		if err != nil {
 			t.Fatalf("%s:\nUnexpected error: %v", test.msg, err)
 		}

--- a/parser.go
+++ b/parser.go
@@ -109,6 +109,10 @@ const (
 	// POSIX processing.
 	PassAfterNonOption
 
+	// EnvironmentFallback lets options be read from environment variables
+	// even if they have no `env` tag, by falling back to the `long` value.
+	EnvironmentFallback
+
 	// Default is a convenient default set of options which should cover
 	// most of the uses of the flags package.
 	Default = HelpFlag | PrintErrors | PassDoubleDash
@@ -170,11 +174,10 @@ func NewParser(data interface{}, options Options) *Parser {
 // be added to this parser by using AddGroup and AddCommand.
 func NewNamedParser(appname string, options Options) *Parser {
 	p := &Parser{
-		Command:            newCommand(appname, "", "", nil),
 		Options:            options,
 		NamespaceDelimiter: ".",
 	}
-
+	p.Command = newCommand(appname, "", "", nil, p)
 	p.Command.parent = p
 
 	return p


### PR DESCRIPTION
We don't want to have e.g. a flag named `"target"` unexpectedly have its default set to the value of `$target`; if you want to use the environment, you need to ask for it.