### PR TITLE
Ability to not specify unit in timeout

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -188,7 +188,10 @@ func convert(val string, retval reflect.Value, options multiTag) error {
 		parsed, err := time.ParseDuration(val)
 
 		if err != nil {
-			return err
+			parsed, err = time.ParseDuration(val + "s")
+			if err != nil {
+				return err
+			}
 		}
 
 		retval.SetInt(int64(parsed))


### PR DESCRIPTION
If parsing time fails, attempt to add 's' unit and parse again. 

Needed for https://github.com/zmap/zgrab2/pull/111