### PR TITLE
fix ini sections ordering

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -480,7 +480,6 @@ func readIni(contents io.Reader, filename string) (*ini, error) {
 		})
 
 		ret.Sections[sectionname] = section
-		ret.OrderedSections = append(ret.OrderedSections, sectionname)
 	}
 
 	return ret, nil


### PR DESCRIPTION
hotfix for [this](https://github.com/zmap/zflags/pull/14)

Previous commit containes bug, that causes sections to be mentioned multiple times in `OrderedSections` array.