### PR TITLE
Implement the ZCommander Help Text

### DIFF
--- a/help.go
+++ b/help.go
@@ -362,6 +362,10 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 				}
 			}
 
+			if zCmd, ok := allcmd.data.(ZCommander); ok {
+				fmt.Fprintf(wr, "\n%s", zCmd.Help())
+			}
+
 			allcmd = allcmd.Active
 		}
 

--- a/help.go
+++ b/help.go
@@ -362,10 +362,6 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 				}
 			}
 
-			if zCmd, ok := allcmd.data.(ZCommander); ok {
-				fmt.Fprintf(wr, "\n%s", zCmd.Help())
-			}
-
 			allcmd = allcmd.Active
 		}
 
@@ -380,6 +376,12 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 
 			fmt.Fprintln(wr, t)
 		}
+
+		if zCmd, ok := allcmd.data.(ZCommander); ok {
+			fmt.Fprintf(wr, "\n%s", zCmd.Help())
+			fmt.Fprintln(wr)
+		}
+
 	}
 
 	c := p.Command

--- a/help.go
+++ b/help.go
@@ -377,7 +377,7 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 			fmt.Fprintln(wr, t)
 		}
 
-		if zCmd, ok := allcmd.data.(ZCommander); ok {
+		if zCmd, ok := cmd.data.(ZCommander); ok {
 			fmt.Fprintf(wr, "\n%s", zCmd.Help())
 			fmt.Fprintln(wr)
 		}

--- a/help.go
+++ b/help.go
@@ -377,8 +377,10 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 			fmt.Fprintln(wr, t)
 		}
 
+		// If the command implements ZCommander, print its help text in between the long description and options
 		if zCmd, ok := cmd.data.(ZCommander); ok {
-			fmt.Fprintf(wr, "\n%s", zCmd.Help())
+			fmt.Fprintln(wr)
+			fmt.Fprintf(wr, "%s", zCmd.Help())
 			fmt.Fprintln(wr)
 		}
 

--- a/help.go
+++ b/help.go
@@ -377,8 +377,8 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 			fmt.Fprintln(wr, t)
 		}
 
-		// If the command implements ZCommander, print its help text in between the long description and options
-		if zCmd, ok := cmd.data.(ZCommander); ok {
+		// If the command implements ZCommander AND provides a help text, print it in between the long description and options
+		if zCmd, ok := cmd.data.(ZCommander); ok && len(zCmd.Help()) > 0 {
 			fmt.Fprintln(wr)
 			fmt.Fprintf(wr, "%s", zCmd.Help())
 			fmt.Fprintln(wr)


### PR DESCRIPTION
The ZCommander interface that we added to go-flags requires commands to add a `Help()` text to satisfy the interface. Thing is, we never printed it. This prints it after the Long Description, see example below.

My two cents is to print it after:
1) Command Options
2) Command Long Description
3) Help Text

I created a test for ZGrab showing where the Help text will now be printed.

```shell
(venv) ⋊> ~/zgrab2 on phillip/98-metadata-file-improvements ⨯ ./zgrab2 http --help                                                                                                                                                                                                                                                                                              15:43:00
Usage:
  zgrab2 [OPTIONS] http [http-OPTIONS]

Send an HTTP request and read the response, optionally following redirects
Ex: echo "en.wikipedia.org" | ./zgrab2 http --max-redirects=1 --endpoint="/wiki/New_York_City"

Random Help Text

General Options:
  -s, --senders=                                              Number of send goroutines to use (default: 1000)
  ...
```