### PR TITLE
Make validation optionally caller-handled for IniParse

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -61,6 +61,11 @@ const (
 type IniParser struct {
 	ParseAsDefaults bool // override default flags
 
+	// NotifyValidateAfterParsing indidcates whether we should Validate any ZCommander fulfilling
+	// commands after parsing has completed.
+	// If true, the caller is responsible for calling the separate Validate method.
+	NoValidateAfterParsing bool
+
 	parser *Parser
 }
 
@@ -641,7 +646,7 @@ func (i *IniParser) parse(ini *ini) ([]string, []interface{}, error) {
 	})
 	// Validate the options after all default settings set
 
-	if !i.parser.NoValidateAfterParsing {
+	if !i.NoValidateAfterParsing {
 		p.eachCommand(func(c *Command) {
 			if cmd, ok := c.data.(ZCommander); ok {
 				if err := cmd.Validate([]string{}); err != nil { //validate

--- a/ini.go
+++ b/ini.go
@@ -647,13 +647,7 @@ func (i *IniParser) parse(ini *ini) ([]string, []interface{}, error) {
 	// Validate the options after all default settings set
 
 	if !i.NoValidateAfterParsing {
-		p.eachCommand(func(c *Command) {
-			if cmd, ok := c.data.(ZCommander); ok {
-				if err := cmd.Validate([]string{}); err != nil { //validate
-					log.Fatal(err)
-				}
-			}
-		}, true)
+		i.ValidateZCommanders()
 	}
 
 	// TODO: checkRequired?

--- a/ini.go
+++ b/ini.go
@@ -159,6 +159,19 @@ func (i *IniParser) Write(writer io.Writer, options IniOptions) {
 	writeIni(i, writer, options)
 }
 
+// ValidateZCommanders validates all commands in the parser that
+// implement the ZCommander interface. If any validation fails, the
+// program will log.Fatal with the error.
+func (i *IniParser) ValidateZCommanders() {
+	i.parser.eachCommand(func(c *Command) {
+		if zcmd, ok := c.data.(ZCommander); ok {
+			if err := zcmd.Validate([]string{}); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}, true)
+}
+
 func readFullLine(reader *bufio.Reader) (string, error) {
 	var line []byte
 

--- a/ini.go
+++ b/ini.go
@@ -628,13 +628,16 @@ func (i *IniParser) parse(ini *ini) ([]string, []interface{}, error) {
 	})
 	// Validate the options after all default settings set
 
-	p.eachCommand(func(c *Command) {
-		if cmd, ok := c.data.(ZCommander); ok {
-			if err := cmd.Validate([]string{}); err != nil { //validate
-				log.Fatal(err)
+	if !i.parser.NoValidateAfterParsing {
+		p.eachCommand(func(c *Command) {
+			if cmd, ok := c.data.(ZCommander); ok {
+				if err := cmd.Validate([]string{}); err != nil { //validate
+					log.Fatal(err)
+				}
 			}
-		}
-	}, true)
+		}, true)
+	}
+
 	// TODO: checkRequired?
 
 	for opt, quoted := range quotesLookup {

--- a/parser.go
+++ b/parser.go
@@ -7,7 +7,6 @@ package flags
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"sort"
@@ -187,19 +186,6 @@ func NewNamedParser(appname string, options Options) *Parser {
 	p.Command.parent = p
 
 	return p
-}
-
-// ValidateZCommanders validates all commands in the parser that
-// implement the ZCommander interface. If any validation fails, the
-// program will log.Fatal with the error.
-func (p *Parser) ValidateZCommanders() {
-	p.eachCommand(func(c *Command) {
-		if zcmd, ok := c.data.(ZCommander); ok {
-			if err := zcmd.Validate([]string{}); err != nil {
-				log.Fatal(err)
-			}
-		}
-	}, true)
 }
 
 // Parse parses the command line arguments from os.Args using Parser.ParseArgs.

--- a/parser.go
+++ b/parser.go
@@ -52,11 +52,6 @@ type Parser struct {
 	// command to be Validated when parsing has finished.
 	CommandHandler func(command Commander, args []string) error
 
-	// NotifyValidateAfterParsing indidcates whether we should Validate any ZCommander fulfilling
-	// commands after parsing has completed.
-	// If true, the caller is responsible for calling the separate Validate method.
-	NoValidateAfterParsing bool
-
 	internalError error
 }
 


### PR DESCRIPTION
Had an issue with ZGrab2 when using both CLI args and an ini file for the `Multiple` module. The desired behavior is that Validation logic for ZCommander is applied _after_ parsing both the ini file AND the CLI args. This is because it's often the case that the ini file alone might fail validation as the user has passed in some args thru CLI args.

This PR allows callers to optionally specify that _they_ will handle calling `Validate` on the IniParser, making it their responsibility. This allows them to parse both the ini file and the CLI args before checking if everything is valid.